### PR TITLE
Enable using the model on GPU

### DIFF
--- a/model.py
+++ b/model.py
@@ -308,7 +308,7 @@ class MambaBlock(nn.Module):
         deltaB_u = einsum(delta, B, u, 'b l d_in, b l n, b l d_in -> b d_in l n')
         
         # Perform selective scan (see scan_SSM() in The Annotated S4 [2])
-        x = torch.zeros((b, d_in, n))
+        x = torch.zeros((b, d_in, n), device=deltaA.device)
         ys = []    
         for i in range(l):
             x = deltaA[:, :, i] * x + deltaB_u[:, :, i]


### PR DESCRIPTION
This small change put `x` on the same device as the model parameters.